### PR TITLE
(hotfix) Fix PHP 8.4 deprecation warning for named parameters

### DIFF
--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -107,7 +107,7 @@ trait HasSlug
                             })->count() === 1;
 
                         if ($slug_parameter_exists) {
-                            $redirect_this = $model->route(slug: $redirect_this);
+                            $redirect_this = $model->route($redirect_this);
                             $to_this = $model->route();
 
                             $redirect_this = Str::of($redirect_this)->remove(config('app.url') . '/');


### PR DESCRIPTION
Remove named parameter 'slug:' from route() method call that was causing PHP 8.4 deprecation warnings