### PR TITLE
Fix slug events firing before database transaction commits

### DIFF
--- a/src/HasSlug.php
+++ b/src/HasSlug.php
@@ -5,6 +5,7 @@ namespace Marshmallow\Sluggable;
 use ReflectionMethod;
 use ReflectionParameter;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Redirect;
 use Marshmallow\Redirectable\Facades\Redirector;
@@ -27,6 +28,7 @@ trait HasSlug
     public function getArtisanCommands(): array
     {
         return [
+            'route:clear',
             'route:cache',
         ];
     }
@@ -83,7 +85,9 @@ trait HasSlug
         });
 
         static::created(function (Model $model) {
-            event(new SlugWasCreated($model));
+            DB::afterCommit(function () use ($model) {
+                event(new SlugWasCreated($model));
+            });
         });
 
         static::updated(function (Model $model) {
@@ -128,7 +132,9 @@ trait HasSlug
                 /**
                  * Trigger event so we can recache the routes.
                  */
-                event(new SlugHasBeenChanged($model));
+                DB::afterCommit(function () use ($model) {
+                    event(new SlugHasBeenChanged($model));
+                });
             }
         });
         static::deleted(function (Model $model) {
@@ -142,7 +148,9 @@ trait HasSlug
             /**
              * Trigger event so we can recache the routes.
              */
-            event(new SlugWasDeleted($model));
+            DB::afterCommit(function () use ($model) {
+                event(new SlugWasDeleted($model));
+            });
         });
     }
 


### PR DESCRIPTION
## Problem

Currently, slug events (SlugWasCreated, SlugHasBeenChanged, SlugWasDeleted) are fired immediately during model lifecycle hooks, but this happens within database transactions before the model changes are actually committed to the database.

This causes issues when:
1. Route caching commands run before the model is persisted
2. Event listeners expect the model to exist in the database
3. External services are called before data is committed

## Solution

- Wrap all event dispatching with `DB::afterCommit()` to defer event firing until after database transactions are committed
- Add `route:clear` to `getArtisanCommands()` before `route:cache` to ensure clean cache regeneration
- Ensures route cache commands work with committed data and event listeners have access to persisted models

## Changes Made

1. **Added DB facade import** for `afterCommit` functionality
2. **Wrapped SlugWasCreated event** in `DB::afterCommit()` 
3. **Wrapped SlugHasBeenChanged event** in `DB::afterCommit()`
4. **Wrapped SlugWasDeleted event** in `DB::afterCommit()`
5. **Added route:clear** to artisan commands before route:cache

## Benefits

- Route caching works reliably
- Events have access to committed data
- Works with both queued and sync event processing  
- No breaking changes to existing event listeners
- Fixes Nova + other transaction-wrapped model creation

Fixes #44