### PR TITLE
docs: refresh README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
+![alt text](https://marshmallow.dev/cdn/media/logo-red-237x46.png "marshmallow.")
+
 # Generate slugs when saving Eloquent models
+
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/marshmallow/sluggable.svg?style=flat-square)](https://packagist.org/packages/marshmallow/sluggable)
+[![Total Downloads](https://img.shields.io/packagist/dt/marshmallow/sluggable.svg?style=flat-square)](https://packagist.org/packages/marshmallow/sluggable)
 
 This package was created by Spatie. We have forked it so we can add new features we need and so we are not dependend on Spatie before we can upgrade to new Laravel versions.
 
@@ -15,9 +20,12 @@ The slugs are generated with Laravels `Str::slug` method, whereby spaces are con
 ## Installation
 
 You can install the package via composer:
-``` bash
+
+```bash
 composer require marshmallow/sluggable
 ```
+
+The package registers its `Marshmallow\Sluggable\SluggableServiceProvider` automatically through Laravel's package discovery, so there is nothing else to wire up.
 
 ## Usage
 
@@ -79,7 +87,7 @@ class CreateYourEloquentModelTable extends Migration
 
 ```
 
-To use the generated slug in routes, remember to use Laravel's [implicit route model binding](https://laravel.com/docs/5.8/routing#implicit-binding):
+To use the generated slug in routes, remember to use Laravel's [implicit route model binding](https://laravel.com/docs/routing#implicit-binding):
 
 ```php
 namespace App;
@@ -153,7 +161,7 @@ public function getSlugOptions() : SlugOptions
 }
 ```
 
-The slug may be slightly longer than the value specified, due to the suffix which is added to make it unique.
+The slug may be slightly longer than the value specified, due to the suffix which is added to make it unique. When no maximum is set, slugs are capped at 250 characters by default.
 
 You can also use a custom separator by calling `usingSeparator`
 
@@ -223,6 +231,59 @@ $model->save(); //slug stays "my-name"
 
 If you want to explicitly update the slug on the model you can call `generateSlug()` on your model at any time to make the slug according to your other options. Don't forget to `save()` the model to persist the update to your database.
 
+### Translatable slugs
+
+If you generate localized routes, let your model implement the `Marshmallow\Sluggable\Contracts\TranslatableSlug` contract. When a model implements this contract and no explicit language has been set on the slug options, the package falls back to the locale returned by `request()->getTranslatableLocale()` when calling `Str::slug`.
+
+```php
+use Marshmallow\Sluggable\HasSlug;
+use Marshmallow\Sluggable\SlugOptions;
+use Illuminate\Database\Eloquent\Model;
+use Marshmallow\Sluggable\Contracts\TranslatableSlug;
+
+class YourEloquentModel extends Model implements TranslatableSlug
+{
+    use HasSlug;
+
+    public function getSlugOptions(): SlugOptions
+    {
+        return SlugOptions::create()
+            ->generateSlugsFrom('name')
+            ->saveSlugsTo('slug');
+    }
+}
+```
+
+You can also seed the available locales up front with `SlugOptions::createWithLocales([...])`.
+
+## Events
+
+Whenever a slug is created, changed or removed the package dispatches an event (after the database transaction has committed):
+
+| Event | Dispatched when |
+| --- | --- |
+| `Marshmallow\Sluggable\Events\SlugWasCreated` | A model with a slug is created. |
+| `Marshmallow\Sluggable\Events\SlugHasBeenChanged` | An existing model's slug field changes on update. |
+| `Marshmallow\Sluggable\Events\SlugWasDeleted` | A model with a slug is deleted. |
+
+Each event exposes the affected model through its public `$model` property.
+
+Out of the box these events are handled by `Marshmallow\Sluggable\Listeners\RunArtisanCommands`, which refreshes cached routes so slug-based URLs stay in sync. By default it runs `route:clear` and `route:cache`, but only when the application's routes are actually cached. You can customize this per model:
+
+- Override `getArtisanCommands(): array` to change which commands run.
+- Override `runArtisanCommandsWhen(): bool` to control when they run (defaults to `app()->routesAreCached()`).
+- Define a `runSluggableArtisanCommands()` method to take over the behaviour entirely.
+
+## Redirects
+
+If your model is also redirectable (it exposes a `redirectable()` relation, e.g. via the `marshmallow/redirectable` package), the package will automatically register a redirect from the old slug to the new one whenever the slug changes, and remove those redirects when the model is deleted.
+
+## Testing
+
+```bash
+composer test
+```
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.
@@ -233,6 +294,7 @@ If you discover any security related issues, please email stef@marshmallow.dev i
 
 ## Credits
 
+- [Stef van Esch](https://github.com/marshmallow-packages)
 - [Freek Van der Herten](https://github.com/freekmurze)
 - [All Contributors](../../contributors)
 


### PR DESCRIPTION
Regenerated README.md using the marshmallow-laravel-readme skill (reads composer.json, service provider, config, src/). No code changes.